### PR TITLE
Render flags and improve responsive behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "node-sass": "^4.13.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.0",
+    "react-country-flag": "^2.1.0",
     "react-dom": "^16.13.0",
     "react-helmet": "^5.2.0",
     "reset-css": "^4.0.1",

--- a/src/components/profile/index.js
+++ b/src/components/profile/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import ReactCountryFlag from "react-country-flag";
 import MapIcon from "../../icons/map";
 import styles from "./profile.module.scss";
 
@@ -46,9 +47,41 @@ const Profile = props => {
       <div className={styles.giftCardBadge}>Gift card only</div>
       <div style={{ backgroundImage: `url(${image})` }} className={styles.image} />
       <div className={styles.card}>
-        <h2 className={styles.name}>{name}</h2>
-        {locationAndCountry(location, country)}
+        <div className={styles.cardHeader}>
+          <div>
+            <h2 className={styles.name}>{name}</h2>
+            {locationAndCountry(location, country)}
+          </div>
+          <div>
+            <ReactCountryFlag
+              className="emojiFlag"
+              countryCode="PH"
+              style={{
+                  fontSize: '1.2em',
+              }}
+              aria-label="Filipino"
+            />
+            <ReactCountryFlag
+              className="emojiFlag"
+              countryCode="JP"
+              style={{
+                  fontSize: '1.2em',
+              }}
+              aria-label="Japanese"
+            />
+            <ReactCountryFlag
+              className="emojiFlag"
+              countryCode="IN"
+              style={{
+                  fontSize: '1.2em',
+              }}
+              aria-label="Indian"
+            />
+          </div>
+        </div>
+        
         <div className={styles.filterTags}>
+          <div className={styles.giftCardBadge}>Gift card only</div>
           <div className={styles.filterTag}>Tag</div>
           <div className={styles.filterTag}>Tag</div>
         </div>

--- a/src/components/profile/profile.module.scss
+++ b/src/components/profile/profile.module.scss
@@ -56,7 +56,7 @@
 
 .image {
   width: 100%;
-  height: 120px;
+  height: 100%;
   background-size: cover;
   background-position: 50%;
 
@@ -69,6 +69,12 @@
   flex: 1 1 auto;
   background-color: #fff;
   padding: 15px;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
 }
 
 .name {
@@ -142,12 +148,30 @@
   right: 0;
   background: #DF280C;
   color: #FFF;
-  margin: 10px; 
+  margin: 10px;
+
+  @media (max-width: $desktop) {
+    display: none;
+  }
 }
 
 .filterTags {
   display: flex;
   margin-top: 40px;
+  align-items: baseline;
+  flex-wrap: wrap;
+
+  @media (max-width: $desktop) {
+    font-size: 13px;
+
+    .giftCardBadge {
+      position: unset;
+      display: flex;
+      margin-left: 0;
+      margin-top: 0;
+    }
+  }
+
 }
 
 .filterTag {

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -53,7 +53,7 @@
   grid-gap: calc(var(--page-shell-padding));
 
   @media (min-width: $non-mobile) {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(1, 1fr);
     grid-gap: 1.5rem;
     @supports not (display: grid) {
       display: block;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10778,6 +10778,11 @@ react-clientside-effect@^1.2.2:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
+react-country-flag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-country-flag/-/react-country-flag-2.1.0.tgz#8c6a70d4c496370112e506b79c5fc2a354841700"
+  integrity sha512-OvPNRYFWpPPoh71vwM/z5dhSQOq8Lbh5Kn6XrQVxLUQ+Ps8+JaP+TQeRS3wk3M3gA+cCc6ZBNSPPXH7+Sep6+Q==
+
 react-dev-utils@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.2.3.tgz#5b42d9ea58d5e9e017a2f57a40a8af408a3a46fb"


### PR DESCRIPTION
- Render flags to represent ethnicity declared by merchant (not dynamic at the moment; represents max of 3)
<img width="626" alt="Screen Shot 2020-05-21 at 10 33 10 PM" src="https://user-images.githubusercontent.com/8534230/82625439-1ad77300-9bb3-11ea-9fdc-0e63e1d67bcb.png">

- Improve responsive behaviour
<img width="473" alt="Screen Shot 2020-05-21 at 10 37 52 PM" src="https://user-images.githubusercontent.com/8534230/82625671-c5e82c80-9bb3-11ea-9fa7-0d1e108b7527.png">

<img width="307" alt="Screen Shot 2020-05-21 at 10 38 00 PM" src="https://user-images.githubusercontent.com/8534230/82625673-c84a8680-9bb3-11ea-94d0-27954abfaf4d.png">

