### PR TITLE
Update font family

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -52,6 +52,15 @@ module.exports = {
           }
         ]
       }
+    },
+    {
+      resolve: 'gatsby-plugin-web-font-loader',
+      options: {
+        typekit: {
+          id: process.env.FONT_KIT_ID
+        }
+      }
+ 
     }
   ],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gatsby-plugin-react-helmet": "^3.1.23",
     "gatsby-plugin-sass": "^2.1.30",
     "gatsby-plugin-sharp": "^2.4.12",
+    "gatsby-plugin-web-font-loader": "^1.0.4",
     "gatsby-remark-smartypants": "^2.1.22",
     "gatsby-source-airtable": "^2.1.0",
     "gatsby-source-filesystem": "^2.1.55",

--- a/src/components/nav/nav.module.scss
+++ b/src/components/nav/nav.module.scss
@@ -22,7 +22,7 @@
 }
 
 .link {
-  font-family: Sofia Pro;
+  font-family: $pt-mono;
   font-style: normal;
   font-weight: normal;
   font-size: 16px;
@@ -44,7 +44,7 @@
   font-weight: bold;
 
   .celebratingContainer {
-    font-family: Sofia Pro;
+    font-family: $pt-mono;
     font-size: 16px;
     line-height: 16px;
     letter-spacing: 2px;
@@ -52,7 +52,7 @@
   }
 
   h1 {
-    font-family: Bennet Banner;
+    font-family: "bennet-banner", "Palatino Linotype", "Book Antiqua", Palatino, serif;
     font-weight: bold;
     font-size: 48px;
     line-height: 50px;

--- a/src/components/profile/profile.module.scss
+++ b/src/components/profile/profile.module.scss
@@ -8,6 +8,7 @@
   overflow-x: hidden;
   font-family: $pt-mono;
   --profile-theme-color: #6362fc;
+  --profile-font-color: #000;
   font-size: 16px;
   border-radius: 20px;
   border: 3px hidden;
@@ -69,17 +70,17 @@
   flex: 1 1 auto;
   background-color: #fff;
   padding: 15px;
+  color: var(--profile-font-color);
 }
 
 .name {
   margin: 0;
-  font-weight: 700;
+  font-weight: 400;
   grid-column: 2 / 5;
   grid-row: 1 / 2;
   align-self: center;
   font-size: 16px;
   padding: 0px;
-  color: var(--profile-theme-color);
   @media (min-width: $desktop) {
     overflow: hidden;
     white-space: nowrap;

--- a/src/pages/about.module.scss
+++ b/src/pages/about.module.scss
@@ -37,7 +37,7 @@
 }
 
 h2.subheading {
-  font-family: Sofia Pro;
+  font-family: $pt-mono;
   font-style: normal;
   font-weight: bold;
   font-size: 16px;
@@ -51,7 +51,7 @@ h2.subheading {
 }
 
 .about {
-  font-family: Sofia Pro;
+  font-family: $pt-mono;
   font-style: normal;
   font-weight: normal;
   font-size: 16px;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,13 +1,13 @@
-@import url("https://fonts.googleapis.com/css2?family=Karla:wght@400;700&display=swap");
+// @import url("https://fonts.googleapis.com/css2?family=Karla:wght@400;700&display=swap");
 
 $sidebar: 310px;
 $non-mobile: 535px;
 $desktop: 820px;
 $s24: 24px;
 $sidebarHeight: 208px;
-$pt-mono: "Karla", Consolas, monaco, monospace;
-$pitch: "Karla", Consolas, monaco, monospace;
-$graphik: "Karla", -apple-system, BlinkMacSystemFont, "avenir next", avenir,
+$pt-mono: "sofia-pro", Consolas, monaco, monospace;
+$pitch: "sofia-pro", Consolas, monaco, monospace;
+$graphik: "sofia-pro", -apple-system, BlinkMacSystemFont, "avenir next", avenir,
   "helvetica neue", helvetica, ubuntu, roboto, noto, "segoe ui", arial, sans-serif;
 
 $sans-serif: -apple-system, BlinkMacSystemFont, "avenir next", avenir, "helvetica neue",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6124,6 +6124,14 @@ gatsby-plugin-sharp@^2.4.12:
     svgo "1.3.2"
     uuid "^3.3.3"
 
+gatsby-plugin-web-font-loader@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-web-font-loader/-/gatsby-plugin-web-font-loader-1.0.4.tgz#c50bdb0c1980110b3fd213a5be70feb2459514c3"
+  integrity sha512-3c39bX9CcsYJQFhhmTyjuMJSqpld2rX+HsTOxP9k1PKFR4Rvo3lpzBW4d1tVpmUesR8BNL6u9eHT7/XksS1iog==
+  dependencies:
+    babel-runtime "^6.26.0"
+    webfontloader "^1.6.28"
+
 gatsby-react-router-scroll@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.2.1.tgz#6fbdb67af08c0f0493503971f4cdc19462f10841"
@@ -13439,6 +13447,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
+
+webfontloader@^1.6.28:
+  version "1.6.28"
+  resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
+  integrity sha1-23hhKSU8tujq5UwvsF+HCvZnW64=
 
 webpack-dev-middleware@^3.7.2:
   version "3.7.2"


### PR DESCRIPTION
Use the Gatsby font loader plugin to import font families from Adobe Fonts.

<img width="1502" alt="Screen Shot 2020-05-22 at 6 27 30 PM" src="https://user-images.githubusercontent.com/8534230/82713713-f4204780-9c59-11ea-831f-5075ea6751ce.png">
